### PR TITLE
feat(type-guards): new `isEmptyObject`

### DIFF
--- a/packages/type-guards/README.md
+++ b/packages/type-guards/README.md
@@ -6,6 +6,7 @@ Available functions:
 - `isUndefined`
 - `isNullOrUndefined`
 - `isEmptyArray`
+- `isEmptyObject`
 - `isNumber`
 - `isBoolean`
 - `isConstructor`

--- a/packages/type-guards/package.json
+++ b/packages/type-guards/package.json
@@ -3,6 +3,12 @@
   "version": "1.3.0",
   "description": "Common type guards for TypeScript projects.",
   "author": "Micael Levi Lima Cavalcante <mllc@icomp.ufam.edu.br>",
+  "maintainers": [
+    "Élrik Souza Silva <elrik.souza@icomp.ufam.edu.br>",
+    "David Braga Fernandes de Oliveira <david@icomp.ufam.edu.br>",
+    "Francisco Oliveira da Silva Filho <francisco.filho@icomp.ufam.edu.br>",
+    "Micael Levi Lima Cavalcante <mllc@icomp.ufam.edu.br>"
+  ],
   "license": "MIT",
   "main": "lib/index",
   "types": "lib/index.d.ts",

--- a/packages/type-guards/src/index.ts
+++ b/packages/type-guards/src/index.ts
@@ -27,11 +27,20 @@ export const isNullOrUndefined = <T>(value: T | null | undefined): value is null
   isNull(value) || isUndefined(value);
 
 /**
- *
  * @param value
- * @returns `true` if the `value` is an empty array, i.e., `value.length === 0`. `false` otherwise
+ * @returns `true` if `value` is an empty array, i.e., `value.length === 0`. `false` otherwise
  */
 export const isEmptyArray = <T extends Array<unknown>>(value: T): boolean => value.length === 0;
+
+/**
+ * @param value
+ * @returns `true` if `value` has no keys. `false` otherwise
+ */
+export const isEmptyObject = <T extends Record<string | number | symbol, unknown>>(
+  value: T,
+): boolean =>
+  Object.getOwnPropertyNames(value).length === 0 &&
+  Object.getOwnPropertySymbols(value).length === 0;
 
 /**
  * Following https://nodejs.org/api/util.html#util_util_isnumber_object

--- a/packages/type-guards/tests/is-empty-object.spec.ts
+++ b/packages/type-guards/tests/is-empty-object.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { isEmptyObject } from '../src';
+
+describe('isEmptyObject(value)', () => {
+  it('should return true', () => {
+    expect(isEmptyObject({})).toBe(true);
+    expect(isEmptyObject(Object.create(null))).toBe(true);
+    expect(isEmptyObject(Object.create({}))).toBe(true);
+    expect(isEmptyObject(Object.create({ foo: 'bar' }))).toBe(true);
+  });
+
+  it('should return false', () => {
+    expect(isEmptyObject({ foo: 'bar' })).toBe(false);
+    expect(isEmptyObject({ 1: 'foo' })).toBe(false);
+    expect(isEmptyObject({ [Symbol('foo')]: 'bar' })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Adiciona

_Type guard_ `isEmptyObject` que verifica se um dado objeto possui alguma chave retornando `true` ou `false`. Apenas objetos são entradas válidas à função, ou seja, devem herdar de `Record<string | number | symbol, unknown>`.